### PR TITLE
install cmake scripts to default location

### DIFF
--- a/mingw-w64-faudio/PKGBUILD
+++ b/mingw-w64-faudio/PKGBUILD
@@ -50,5 +50,4 @@ package() {
   make DESTDIR=${pkgdir} install
 
   install -Dm644 ${srcdir}/${_realname}/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
-  mv ${pkgdir}${MINGW_PREFIX}/lib/cmake ${pkgdir}${MINGW_PREFIX}/share/
 }


### PR DESCRIPTION
/mingw64/lib/cmake/FAudio is the default location and it works correctly.